### PR TITLE
Version 5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library provides a set of classes that help represent requests for complex data and provides a way to convert requests to and from a standard JSON format. If you have interfaces with tons of parameters (filters, groupings, page, rowsPerPage, etc.), or if you're just looking for a standard way to communicate complex requests to other apps without racking your brain over how to represent this data in JSON, you will like this library.
 
-- **Version:** 5.2.0
+- **Version:** 5.3.0
 
 [![Build Status](https://travis-ci.org/mongerinc/search-request.js.png?branch=master)](https://travis-ci.org/mongerinc/search-request.js)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 5.3.0
+- Automatically resetting the page to 1 whenever a filter, term, sort, or grouping changes. Same for facets with the other filter/sort changes.
+
 ### 5.2.0
 - Handle deep-cloning of the search request
 - Avoid returning the search request from getFilter and getFilterValue methods

--- a/src/facet.js
+++ b/src/facet.js
@@ -5,16 +5,26 @@ function Facet(values)
 	if (!values || typeof values !== 'object')
 		throw new Error("A Facet object must be instantiated with an object of input values.");
 
+	this.page = 1;
+	this.limit = 10;
+
 	this.setField(values.field);
 	this.setSortType(values.hasOwnProperty('sortType') ? values.sortType : 'value');
 	this.setSortDirection(values.hasOwnProperty('sortDirection') ? values.sortDirection : 'asc');
-	this.setPage(values.hasOwnProperty('page') ? values.page : 1);
-	this.setLimit(values.hasOwnProperty('limit') ? values.limit : 10);
 	this.setMinimumCount(values.hasOwnProperty('minimumCount') ? values.minimumCount : 1);
 	this.setExcludesOwnFilters(values.hasOwnProperty('excludesOwnFilters') ? values.excludesOwnFilters : true);
+	this.setPage(values.hasOwnProperty('page') ? values.page : this.page);
+	this.setLimit(values.hasOwnProperty('limit') ? values.limit : this.limit);
 }
 
 Facet.prototype = {
+
+	/**
+	 * Determines if the page should reset when filter/sort changes
+	 *
+	 * @var bool
+	 */
+	pageShouldAutomaticallyReset: true,
 
 	/**
 	 * @return string
@@ -135,6 +145,9 @@ Facet.prototype = {
 
 		this.sortType = type;
 
+		if (this.pageShouldAutomaticallyReset)
+			this.setPage(1);
+
 		return this;
 	},
 
@@ -149,6 +162,9 @@ Facet.prototype = {
 			throw new Error("The sort direction must be either 'asc' or 'desc'.");
 
 		this.sortDirection = direction;
+
+		if (this.pageShouldAutomaticallyReset)
+			this.setPage(1);
 
 		return this;
 	},
@@ -205,6 +221,9 @@ Facet.prototype = {
 
 		this.minimumCount = parseInt(minimumCount);
 
+		if (this.pageShouldAutomaticallyReset)
+			this.setPage(1);
+
 		return this;
 	},
 
@@ -232,6 +251,33 @@ Facet.prototype = {
 	setExcludesOwnFilters: function(value)
 	{
 		this.excludesOwnFilters = !!value;
+
+		if (this.pageShouldAutomaticallyReset)
+			this.setPage(1);
+
+		return this;
+	},
+
+	/**
+	 * Disables automatic page resetting
+	 *
+	 * @return this
+	 */
+	disableAutomaticPageReset: function()
+	{
+		this.pageShouldAutomaticallyReset = false;
+
+		return this;
+	},
+
+	/**
+	 * Enables automatic page resetting
+	 *
+	 * @return this
+	 */
+	enableAutomaticPageReset: function()
+	{
+		this.pageShouldAutomaticallyReset = true;
 
 		return this;
 	},

--- a/tests/facet/facet.js
+++ b/tests/facet/facet.js
@@ -110,4 +110,52 @@ describe('facet', function()
 		});
 	});
 
+	it("should reset page by default", function()
+	{
+		var facet = request.facet('someField');
+
+		facet.setPage(5).sortByCount();
+		expect(facet.getPage()).toEqual(1);
+
+		facet.setPage(5).sortByValue();
+		expect(facet.getPage()).toEqual(1);
+
+		facet.setPage(5).setMinimumCount(5);
+		expect(facet.getPage()).toEqual(1);
+
+		facet.setPage(5).excludeOwnFilters();
+		expect(facet.getPage()).toEqual(1);
+
+		facet.setPage(5).includeOwnFilters();
+		expect(facet.getPage()).toEqual(1);
+	});
+
+	it("should not reset page when disabled", function()
+	{
+		var facet = request.facet('someField').disableAutomaticPageReset();
+
+		facet.setPage(5).sortByCount();
+		expect(facet.getPage()).toEqual(5);
+
+		facet.setPage(5).sortByValue();
+		expect(facet.getPage()).toEqual(5);
+
+		facet.setPage(5).setMinimumCount(5);
+		expect(facet.getPage()).toEqual(5);
+
+		facet.setPage(5).excludeOwnFilters();
+		expect(facet.getPage()).toEqual(5);
+
+		facet.setPage(5).includeOwnFilters();
+		expect(facet.getPage()).toEqual(5);
+	});
+
+	it("should reset page when reenabled", function()
+	{
+		var facet = request.facet('someField').disableAutomaticPageReset().enableAutomaticPageReset();
+
+		facet.setPage(5).sortByCount();
+		expect(facet.getPage()).toEqual(1);
+	});
+
 });

--- a/tests/json/json.js
+++ b/tests/json/json.js
@@ -21,8 +21,7 @@ describe('json', function()
 	{
 		var request = new SearchRequest;
 
-		request.setPage(5).setLimit(50)
-		       .setTerm('search this')
+		request.setTerm('search this')
 		       .select(['field1', 'field2'])
 		       .addSort('something', 'asc').addSort('otherThing', 'desc')
 		       .groupBy('something').groupBy('somethingElse')
@@ -30,7 +29,8 @@ describe('json', function()
 		       {
 		           filterSet.where('hats', '>', 'large').where('butts', 'small');
 		       })
-		       .facet('something').setPage(2).setLimit(100).sortByCount().setSortDirection('desc').setMinimumCount(5).includeOwnFilters();
+		       .setPage(5).setLimit(50)
+		       .facet('something').sortByCount().setSortDirection('desc').setMinimumCount(5).includeOwnFilters().setPage(2).setLimit(100);
 
 		return request;
 	}
@@ -54,11 +54,11 @@ describe('json', function()
 			groups: ['something', 'somethingElse'],
 			facets: [
 				{
+					page: 2,
+					limit: 100,
 					field: 'something',
 					sortType: 'count',
 					sortDirection: 'desc',
-					page: 2,
-					limit: 100,
 					minimumCount: 5,
 					excludesOwnFilters: false,
 				}

--- a/tests/pagination/pagination.js
+++ b/tests/pagination/pagination.js
@@ -45,4 +45,44 @@ describe('pagination', function()
 		expect(request.getLimit()).toEqual(100);
 		expect(request.getSkip()).toEqual(100);
 	});
+
+	it("should reset page by default", function()
+	{
+		request.setPage(5).where('foo', true);
+		expect(request.getPage()).toEqual(1);
+
+		request.setPage(5).sortBy('foo', 'desc');
+		expect(request.getPage()).toEqual(1);
+
+		request.setPage(5).groupBy('foo');
+		expect(request.getPage()).toEqual(1);
+
+		request.setPage(5).setTerm('foo');
+		expect(request.getPage()).toEqual(1);
+	});
+
+	it("should not reset page when disabled", function()
+	{
+		request.disableAutomaticPageReset();
+
+		request.setPage(5).where('foo', true);
+		expect(request.getPage()).toEqual(5);
+
+		request.setPage(5).sortBy('foo', 'desc');
+		expect(request.getPage()).toEqual(5);
+
+		request.setPage(5).groupBy('foo');
+		expect(request.getPage()).toEqual(5);
+
+		request.setPage(5).setTerm('foo');
+		expect(request.getPage()).toEqual(5);
+	});
+
+	it("should reset page when reenabled", function()
+	{
+		request.disableAutomaticPageReset().enableAutomaticPageReset();
+
+		request.setPage(5).where('foo', true);
+		expect(request.getPage()).toEqual(1);
+	});
 });


### PR DESCRIPTION
Automatically resetting the page to 1 whenever a filter, term, sort, or grouping changes. Same for facets with the other filter/sort changes.